### PR TITLE
Fixed nullable properties bug

### DIFF
--- a/src/Exceptions/RepositoryException.php
+++ b/src/Exceptions/RepositoryException.php
@@ -11,10 +11,11 @@ use Exception;
  */
 final class RepositoryException extends Exception
 {
-    public const REPOSITORY_MUST_IMPLEMENTS = "The repository must implements IRepository interface";
-    public const MODEL_MUST_IMPLEMENTS = "The model must implement IModel interface";
-    public const MODEL_IS_NOT_ENTITY = "The model has no entity attribute";
-    public const FETCH_BY_ID_MULTIPLE_RESULTS = "Retrieved more than one object when fetching by id!";
-    public const RELATED_OBJECT_NOT_FOUND = "Related object not found";
-    public const NO_MODEL_DATA_FOUND = "No bindable data found in the model fields";
+    public const string REPOSITORY_MUST_IMPLEMENTS = "The repository must implements IRepository interface";
+    public const string MODEL_MUST_IMPLEMENTS = "The model must implement IModel interface";
+    public const string MODEL_IS_NOT_ENTITY = "The model has no entity attribute";
+    public const string FETCH_BY_ID_MULTIPLE_RESULTS = "Retrieved more than one object when fetching by id!";
+    public const string RELATED_OBJECT_NOT_FOUND = "Related object not found";
+    public const string NO_MODEL_DATA_FOUND = "No bindable data found in the model fields";
+    public const string INVALID_PROMOTED_PROPERTY = "Invalid promoted property";
 }

--- a/src/Repository/AbstractRepository.php
+++ b/src/Repository/AbstractRepository.php
@@ -23,6 +23,7 @@ use PDOStatement;
 use ReflectionClass;
 use ReflectionException;
 use Exception;
+use ReflectionParameter;
 
 /**
  * The abstract class from which extends the repository
@@ -89,6 +90,7 @@ abstract class AbstractRepository
      * @param ReflectionClass $reflectionClass
      * @return void
      * @throws ReflectionException
+     * @throws Exceptions\RepositoryException
      */
     private function processModel(ReflectionClass $reflectionClass): void
     {
@@ -131,9 +133,6 @@ abstract class AbstractRepository
                     );
                 }
 
-                // If it doesn't have a default value and is not a key identity then it's required
-                $isRequired = !$reflectionProperty->hasDefaultValue() && !$isIdentity;
-
                 // We get the ENUM type of Enums/Relationship if it is a foreign key and the column name
                 if ($attributeName === Attributes\ForeignKey::class) {
                     $typeOfFk = ReflectionUtility::invokeMethodOfClass(
@@ -150,9 +149,30 @@ abstract class AbstractRepository
                 }
             }
 
+            /**
+             * This check had to be made due to a bug/bad documentation of the method {@see ReflectionProperty::hasDefaultValue()}
+             * that doesn't work with promoted properties.
+             */
+            if (!$reflectionProperty->isPromoted()) {
+                // If it doesn't have a default value and is not a key identity then it's required
+                $isRequired = !$reflectionProperty->hasDefaultValue() && !$isIdentity;
+            } else {
+                /**
+                 * If it's a promoted property check the default value in the constructor by getting the reflection parameter
+                 */
+                $constructorParams = $reflectionClass->getConstructor()->getParameters();
+                $foundParams = array_values(array_filter($constructorParams, fn(ReflectionParameter $param) => $param->getName() === $reflectionProperty->getName()));
+
+                if (empty($foundParams) || count($foundParams) > 1) {
+                    throw new Exceptions\RepositoryException(Exceptions\RepositoryException::INVALID_PROMOTED_PROPERTY);
+                }
+
+                $isRequired = !($foundParams[0]->isDefaultValueAvailable()) && !$isIdentity;
+            }
+
             // Get property name and type
             $propertyName = $reflectionProperty->getName();
-            $propertyType = strval($reflectionProperty->getType());
+            $propertyType = $reflectionProperty->getType()->getName();
 
             $this->modelHandler->save(
                 fieldName: $propertyName,

--- a/tests/Models/T1.php
+++ b/tests/Models/T1.php
@@ -6,13 +6,21 @@ namespace AbstractRepo\Test\Models;
 
 use AbstractRepo\Attributes\Entity;
 use AbstractRepo\Attributes\Key;
+use AbstractRepo\Attributes\Searchable;
 use AbstractRepo\Interfaces\IModel;
+use JetBrains\PhpStorm\Deprecated;
 
 #[Entity]
-class T1 implements IModel{
+class T1 implements IModel
+{
     public function __construct(
         #[Key(false)]
-        public int $id,
-        public string $v1
-    ){}
+        public int     $id,
+        #[Searchable]
+        public string  $v1,
+        #[Searchable]
+        public ?string $v2 = null
+    )
+    {
+    }
 }

--- a/tests/test_schema.sql
+++ b/tests/test_schema.sql
@@ -7,6 +7,7 @@ USE abstract_repo_test;
 CREATE TABLE T1(
     id int not null AUTO_INCREMENT,
     v1 varchar(255) not null,
+    v2 varchar(255) null,
     PRIMARY KEY(id)
 );
 


### PR DESCRIPTION
The issue was relying on the bug/bad documentation of the method ReflectionProperty::hasDefaultValue() which was returning a wrong boolean in case of a promoted property. Since promoted properties are defined in the constructor, I've resolved this issue by just getting the default value from the ReflectionParameter instead of the ReflectionProperty.